### PR TITLE
Patches the single sort case where on node toString is not called.

### DIFF
--- a/es5/engine.js
+++ b/es5/engine.js
@@ -45,6 +45,32 @@ var Engine = (function () {
   }
 
   _createClass(Engine, [{
+    key: 'search',
+    value: function search(req) {
+      return _superagent2['default'].get('' + this.target + '/search').query((0, _request.searchRequest)(req));
+    }
+  }, {
+    key: 'msearch',
+    value: function msearch(req) {
+      return _superagent2['default'].get('' + this.target + '/msearch').query((0, _request.multiSearchRequest)(req));
+    }
+  }, {
+    key: 'typeahead',
+    value: function typeahead(req) {
+      return _superagent2['default'].get('' + this.target + '/typeahead').query((0, _request.typeaheadRequest)(req));
+    }
+  }, {
+    key: 'vrec',
+    value: function vrec(req) {
+      return _superagent2['default'].get('' + this.target + '/vrec').query((0, _request.similarRequest)(req));
+    }
+  }, {
+    key: 'feedback',
+    value: function feedback(req) {
+      var treq = trackRequest(req);
+      return _superagent2['default'].get('' + this.target + '/track/' + treq.type).query(treq.query);
+    }
+  }, {
     key: 'fq',
     get: function () {
       return '' + this.company + '.' + this.environment + '.' + this.instance;
@@ -72,32 +98,6 @@ var Engine = (function () {
     key: 'target',
     get: function () {
       return '' + this.protocol + '://' + this.cluster + '.search.blackbird.am/' + this.fq;
-    }
-  }, {
-    key: 'search',
-    value: function search(req) {
-      return _superagent2['default'].get('' + this.target + '/search').query((0, _request.searchRequest)(req));
-    }
-  }, {
-    key: 'msearch',
-    value: function msearch(req) {
-      return _superagent2['default'].get('' + this.target + '/msearch').query((0, _request.multiSearchRequest)(req));
-    }
-  }, {
-    key: 'typeahead',
-    value: function typeahead(req) {
-      return _superagent2['default'].get('' + this.target + '/typeahead').query((0, _request.typeaheadRequest)(req));
-    }
-  }, {
-    key: 'vrec',
-    value: function vrec(req) {
-      return _superagent2['default'].get('' + this.target + '/vrec').query((0, _request.similarRequest)(req));
-    }
-  }, {
-    key: 'feedback',
-    value: function feedback(req) {
-      var treq = trackRequest(req);
-      return _superagent2['default'].get('' + this.target + '/track/' + treq.type).query(treq.query);
     }
   }]);
 

--- a/es5/facet.js
+++ b/es5/facet.js
@@ -101,14 +101,14 @@ var HistFacet = (function (_Facet2) {
   _inherits(HistFacet, _Facet2);
 
   _createClass(HistFacet, [{
-    key: 'range',
-    get: function () {
-      return '[' + this.start + ':' + this.end + ':' + this.gap + ']';
-    }
-  }, {
     key: 'toString',
     value: function toString() {
       return _get(Object.getPrototypeOf(HistFacet.prototype), 'toString', this).call(this, 'type=hist/range=' + this.range());
+    }
+  }, {
+    key: 'range',
+    get: function () {
+      return '[' + this.start + ':' + this.end + ':' + this.gap + ']';
     }
   }]);
 

--- a/es5/filter.js
+++ b/es5/filter.js
@@ -52,14 +52,6 @@ var Filter = (function () {
       return this;
     }
   }, {
-    key: 'tagString',
-    get: function () {
-      if (this._tag) {
-        return '/tag=' + this._tag;
-      }
-      return '';
-    }
-  }, {
     key: 'toString',
     value: function toString() {
       var expressions = this.expressions.reduce(function (result, exp) {
@@ -67,6 +59,14 @@ var Filter = (function () {
       }, '');
 
       return 'exp=' + expressions + '' + this.tagString;
+    }
+  }, {
+    key: 'tagString',
+    get: function () {
+      if (this._tag) {
+        return '/tag=' + this._tag;
+      }
+      return '';
     }
   }]);
 

--- a/es5/request.js
+++ b/es5/request.js
@@ -36,6 +36,8 @@ var Request = (function () {
         return input.map(function (sort) {
           return sort.toString();
         }).join(',');
+      } else if (typeof input !== 'undefined') {
+        return input.toString();
       }
       return input;
     }

--- a/es6/request.js
+++ b/es6/request.js
@@ -12,6 +12,8 @@ export class Request {
   static handleSorts(input) {
     if(Array.isArray(input)) {
       return input.map((sort) => sort.toString()).join(',');
+    }else if(typeof input !== 'undefined'){
+      return input.toString();
     }
     return input;
   }

--- a/merlin.js
+++ b/merlin.js
@@ -142,14 +142,6 @@
 	      return this;
 	    }
 	  }, {
-	    key: 'tagString',
-	    get: function () {
-	      if (this._tag) {
-	        return '/tag=' + this._tag;
-	      }
-	      return '';
-	    }
-	  }, {
 	    key: 'toString',
 	    value: function toString() {
 	      var expressions = this.expressions.reduce(function (result, exp) {
@@ -157,6 +149,14 @@
 	      }, '');
 
 	      return 'exp=' + expressions + '' + this.tagString;
+	    }
+	  }, {
+	    key: 'tagString',
+	    get: function () {
+	      if (this._tag) {
+	        return '/tag=' + this._tag;
+	      }
+	      return '';
 	    }
 	  }]);
 
@@ -211,7 +211,7 @@
 
 /***/ },
 /* 2 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ function(module, exports) {
 
 	'use strict';
 
@@ -524,14 +524,14 @@
 	  _inherits(HistFacet, _Facet2);
 
 	  _createClass(HistFacet, [{
-	    key: 'range',
-	    get: function () {
-	      return '[' + this.start + ':' + this.end + ':' + this.gap + ']';
-	    }
-	  }, {
 	    key: 'toString',
 	    value: function toString() {
 	      return _get(Object.getPrototypeOf(HistFacet.prototype), 'toString', this).call(this, 'type=hist/range=' + this.range());
+	    }
+	  }, {
+	    key: 'range',
+	    get: function () {
+	      return '[' + this.start + ':' + this.end + ':' + this.gap + ']';
 	    }
 	  }]);
 
@@ -712,6 +712,8 @@
 	        return input.map(function (sort) {
 	          return sort.toString();
 	        }).join(',');
+	      } else if (typeof input !== 'undefined') {
+	        return input.toString();
 	      }
 	      return input;
 	    }
@@ -890,6 +892,32 @@
 	  }
 
 	  _createClass(Engine, [{
+	    key: 'search',
+	    value: function search(req) {
+	      return _superagent2['default'].get('' + this.target + '/search').query((0, _request.searchRequest)(req));
+	    }
+	  }, {
+	    key: 'msearch',
+	    value: function msearch(req) {
+	      return _superagent2['default'].get('' + this.target + '/msearch').query((0, _request.multiSearchRequest)(req));
+	    }
+	  }, {
+	    key: 'typeahead',
+	    value: function typeahead(req) {
+	      return _superagent2['default'].get('' + this.target + '/typeahead').query((0, _request.typeaheadRequest)(req));
+	    }
+	  }, {
+	    key: 'vrec',
+	    value: function vrec(req) {
+	      return _superagent2['default'].get('' + this.target + '/vrec').query((0, _request.similarRequest)(req));
+	    }
+	  }, {
+	    key: 'feedback',
+	    value: function feedback(req) {
+	      var treq = trackRequest(req);
+	      return _superagent2['default'].get('' + this.target + '/track/' + treq.type).query(treq.query);
+	    }
+	  }, {
 	    key: 'fq',
 	    get: function () {
 	      return '' + this.company + '.' + this.environment + '.' + this.instance;
@@ -917,32 +945,6 @@
 	    key: 'target',
 	    get: function () {
 	      return '' + this.protocol + '://' + this.cluster + '.search.blackbird.am/' + this.fq;
-	    }
-	  }, {
-	    key: 'search',
-	    value: function search(req) {
-	      return _superagent2['default'].get('' + this.target + '/search').query((0, _request.searchRequest)(req));
-	    }
-	  }, {
-	    key: 'msearch',
-	    value: function msearch(req) {
-	      return _superagent2['default'].get('' + this.target + '/msearch').query((0, _request.multiSearchRequest)(req));
-	    }
-	  }, {
-	    key: 'typeahead',
-	    value: function typeahead(req) {
-	      return _superagent2['default'].get('' + this.target + '/typeahead').query((0, _request.typeaheadRequest)(req));
-	    }
-	  }, {
-	    key: 'vrec',
-	    value: function vrec(req) {
-	      return _superagent2['default'].get('' + this.target + '/vrec').query((0, _request.similarRequest)(req));
-	    }
-	  }, {
-	    key: 'feedback',
-	    value: function feedback(req) {
-	      var treq = trackRequest(req);
-	      return _superagent2['default'].get('' + this.target + '/track/' + treq.type).query(treq.query);
 	    }
 	  }]);
 
@@ -2104,7 +2106,7 @@
 
 /***/ },
 /* 9 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ function(module, exports) {
 
 	
 	/**
@@ -2274,7 +2276,7 @@
 
 /***/ },
 /* 10 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ function(module, exports) {
 
 	
 	/**


### PR DESCRIPTION
The important lines of this PR are in request.js.  The rest is simply the result of the build - if you prefer to build yourself, feel free to just take the small change and reject this PR.

The core of the issue here is when there is only one sort specified and you are running the search on node, server-side, it is not calling toString automatically.  This is resulting in a different sorting of results between client and server.  

I did not know where you wanted this tested, so I left that out.  

Thanks!