### PR TITLE
Handle numbers in mEscape method

### DIFF
--- a/es5/helpers.js
+++ b/es5/helpers.js
@@ -59,10 +59,14 @@ function isObject(obj) {
   return obj === Object(obj);
 }
 
+function toString(val) {
+  return val == null ? '' : (val + '');
+}
+
 function mEscape(str) {
   var escChar = '\\';
   var re = /(\!|\,|\||\\|\/)/g;
-  var escaped = str.replace(re, function (a) {
+  var escaped = toString(str).replace(re, function (a) {
     return '' + escChar + '' + a;
   });
   if (escaped.endsWith(escChar)) {

--- a/es5/test.js
+++ b/es5/test.js
@@ -12,6 +12,8 @@ var _es52 = _interopRequireDefault(_es5);
 
 var _es5Request = require('../es5/request');
 
+var _es5Helpers = require('../es5/helpers');
+
 describe('Blackbird', function () {
   // Blackbird.Filter
   describe('Filter', function () {
@@ -38,6 +40,22 @@ describe('Blackbird', function () {
     it('should allow OR chaining');
     it('should allow AND chaining');
     it('should allow tagging');
+    describe('toString', function () {
+      it('should return the correct string when value is a string', function () {
+        _es52['default'].cnfFilter({
+          field: 'color',
+          operator: '=',
+          value: 'black'
+        }).toString().should.equal('exp=color:black/type=cnf');
+      });
+      it('should return the correct string when value is a number', function () {
+        _es52['default'].cnfFilter({
+          field: 'price',
+          operator: '<',
+          value: 100
+        }).toString().should.equal('exp=price:(:100)/type=cnf');
+      });
+    });
   });
 
   // Blackbird.Facet
@@ -279,6 +297,28 @@ describe('Blackbird', function () {
         _should2['default'].not.exist(err);
         _should2['default'].exist(res);
         done(err, res);
+      });
+    });
+  });
+  describe('helpers', function () {
+    describe('mEscape', function () {
+      it('should escape !', function () {
+        (0, _es5Helpers.mEscape)('Test!').should.equal('Test\\!');
+      });
+      it('should escape ,', function () {
+        (0, _es5Helpers.mEscape)('Test,1').should.equal('Test\\,1');
+      });
+      it('should escape |', function () {
+        (0, _es5Helpers.mEscape)('Test|1').should.equal('Test\\|1');
+      });
+      it('should escape \\', function () {
+        (0, _es5Helpers.mEscape)('Test\\1').should.equal('Test\\\\1');
+      });
+      it('should escape /', function () {
+        (0, _es5Helpers.mEscape)('Test/1').should.equal('Test\\/1');
+      });
+      it('should handle numbers', function () {
+        (0, _es5Helpers.mEscape)(2).should.equal('2');
       });
     });
   });

--- a/es6/helpers.js
+++ b/es6/helpers.js
@@ -44,10 +44,14 @@ function isObject(obj) {
   return obj === Object(obj);
 }
 
+function toString(val) {
+  return val == null ? '' : (val + '');
+}
+
 export function mEscape(str) {
   const escChar = '\\';
   const re = /(\!|\,|\||\\|\/)/g;
-  const escaped = str.replace(re, a => `${escChar}${a}`);
+  const escaped = toString(str).replace(re, a => `${escChar}${a}`);
   if (escaped.endsWith(escChar)) {
     throw new Error(`${str} contains a hanging escape-character (\\) at the end`);
   }

--- a/es6/test.js
+++ b/es6/test.js
@@ -3,6 +3,7 @@
 import should from 'should';
 import Blackbird from '../es5';
 import {SearchRequest} from '../es5/request';
+import {mEscape} from '../es5/helpers';
 
 describe('Blackbird', () => {
   // Blackbird.Filter
@@ -28,6 +29,22 @@ describe('Blackbird', () => {
     it('should allow OR chaining');
     it('should allow AND chaining');
     it('should allow tagging');
+    describe('toString', () => {
+      it('should return the correct string when value is a string', () => {
+        Blackbird.cnfFilter({
+          field: 'color',
+          operator: '=',
+          value: 'black'
+        }).toString().should.equal('exp=color:black/type=cnf');
+      });
+      it('should return the correct string when value is a number', () => {
+        Blackbird.cnfFilter({
+          field: 'price',
+          operator: '<',
+          value: 100
+        }).toString().should.equal('exp=price:(:100)/type=cnf');
+      });
+    });
   });
 
   // Blackbird.Facet
@@ -282,6 +299,28 @@ describe('Blackbird', () => {
         should.not.exist(err);
         should.exist(res);
         done(err, res);
+      });
+    });
+  });
+  describe('helpers', function() {
+    describe('mEscape', function() {
+      it('should escape !', function() {
+        mEscape('Test!').should.equal('Test\\!');
+      });
+      it('should escape ,', function() {
+        mEscape('Test,1').should.equal('Test\\,1');
+      });
+      it('should escape |', function() {
+        mEscape('Test|1').should.equal('Test\\|1');
+      });
+      it('should escape \\', function() {
+        mEscape('Test\\1').should.equal('Test\\\\1');
+      });
+      it('should escape /', function() {
+        mEscape('Test/1').should.equal('Test\\/1');
+      });
+      it('should handle numbers', function() {
+        mEscape(2).should.equal('2');
       });
     });
   });


### PR DESCRIPTION
This fixes the handling of non-strings in the mEscape function in helpers.js.

With the release of 5.5 we started getting errors calling expression.toString(). This was happening when the expression value was a number. The mEscape function in helpers.js was assuming that the argument was a string.

For example, the following would throw a TypeError:
```
var filter = Blackbird.cnfFilter({field: 'price', operator: '=', value: 100});
console.log(filter.toString());
```

#### Summary of changes:
- Added a helper method, `toString`, to helpers.js to convert the input to string.
- Changed `mEscape` to use call `toString` before doing the replace. 
- Added tests for `mEscape`.
- Added tests for `Expression.toString`.